### PR TITLE
Migrate dimensions date column to a date type

### DIFF
--- a/app/models/dimensions/date_builder.rb
+++ b/app/models/dimensions/date_builder.rb
@@ -7,7 +7,7 @@ module Dimensions
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def date_dimension
       Dimensions::Date.new(
-        date: date.strftime('%-d/%-m/%Y'),
+        date: date,
         date_name: date_name,
         date_name_abbreviated: date_name_abbreviated,
         year: year,

--- a/db/migrate/20160301145407_change_dimensions_dates_date.rb
+++ b/db/migrate/20160301145407_change_dimensions_dates_date.rb
@@ -1,0 +1,5 @@
+class ChangeDimensionsDatesDate < ActiveRecord::Migration
+  def change
+    change_column :dimensions_dates, :date, 'date USING date::date'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229155654) do
+ActiveRecord::Schema.define(version: 20160301145407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "dimensions_dates", force: :cascade do |t|
-    t.string   "date",                   null: false
+    t.date     "date",                   null: false
     t.string   "date_name",              null: false
     t.string   "date_name_abbreviated",  null: false
     t.integer  "year",                   null: false

--- a/features/step_definitions/dimensions/date_steps.rb
+++ b/features/step_definitions/dimensions/date_steps.rb
@@ -7,5 +7,7 @@ When(/^we build a date dimension for that date$/) do
 end
 
 Then(/^we can constrain or group on (.*), eg (.*)$/) do |characteristic, example|
+  example = Date.parse(example).to_s if characteristic == 'date'
+
   expect(@date_dimension.public_send(characteristic).to_s).to eq(example)
 end

--- a/spec/models/dimensions/date_builder_spec.rb
+++ b/spec/models/dimensions/date_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dimensions::DateBuilder do
     subject(:date_dimension) { date_dimension_builder.date_dimension }
 
     it "maps the `date' attribute" do
-      expect(date_dimension.date).to eq('29/2/2016')
+      expect(date_dimension.date).to eq(Date.new(year, month, day))
     end
 
     it "maps the `date_name' attribute" do


### PR DESCRIPTION
We should represent dates as dates in the database so that we can correctly constrain our queries. Using a string means currently means we have to cast the data overtime we query :(